### PR TITLE
Documentar o arquivo MJDA e renovar a vitrine inicial

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS.md
+
+Orientacoes para Codex, Claude, Grok, Gemini e outros agentes trabalhando neste repositorio:
+
+- Preserve o material `codei-na-unha` como museu do trabalho original do MJDA. Evite reescrever historia; prefira registrar contexto.
+- Nao reverta trabalho alheio. Se encontrar mudancas que voce nao fez, trate como trabalho em andamento de outra pessoa/agente.
+- Documente mudancas relevantes no arquivo apropriado da familia `LEIAME.md` / `README.md` / `LEEME.md` ou em notas claras no proprio commit/contexto da tarefa.
+- Mantenha o projeto compativel com GitHub Pages estatico. Evite dependencias de build, backend ou servicos externos obrigatorios.
+- Use pt-BR como fonte canonica da documentacao.
+- Ao criar documentacao importante, mantenha a triade `LEIAME.md` / `README.md` / `LEEME.md` quando fizer sentido.
+- Ao iterar experiencias, prefira novos espacos `v0`/`v1` ou destinos futuros como `laboratelier`, sem apagar o estado preservado.

--- a/LEEME.md
+++ b/LEEME.md
@@ -1,0 +1,36 @@
+# MJDA: archivo de experiencias interactivas
+
+DOCS: [LEIAME.MD](LEIAME.md) / [README.MD](README.md) / [LEEME.MD](LEEME.md)
+
+Este repositorio preserva y organiza experiencias interactivas creadas en el Master en Periodismo de Datos, Automatizacion y Data Storytelling (MJDA). Funciona como un archivo publico del recorrido en el curso: pequenos protoartefactos de periodismo de datos, visualizacion y narrativa interactiva, publicados como paginas estaticas.
+
+## Experiencias
+
+- [Calculadora / timeline](calc/): calculadora de generaciones con navegacion horizontal y una version experimental en `calc/exp/`.
+- [Mapa](mapa/): visualizacion sobre matrimonios LGBT por estado brasileno y genero.
+- [Quiz](quiz/): quiz visual sobre economia y PIB usando banderas y barras.
+- [Scroll](scroll/): narrativa en scroll sobre Google Phones.
+
+## Convencion del archivo
+
+Este repositorio separa preservacion historica de nuevas iteraciones:
+
+- `codei-na-unha`: espacio de museo/preservacion del trabajo original hecho en el MJDA. Debe tratarse como registro historico, con cambios minimos y bien documentados.
+- `v0` / `v1`: nuevas iteraciones asistidas por agentes, usadas para probar mejoras, reorganizar interfaces y explorar caminos sin borrar la autoria ni el estado original.
+- `laboratelier`: destino futuro de los protoartefactos vivos, cuando una experiencia deje de ser solo archivo del curso y pase a existir como laboratorio en evolucion.
+
+## Licencia
+
+La licencia actual del repositorio es [MIT](LICENSE).
+
+En lenguaje directo, permite usar, copiar, modificar, distribuir y vender copias de este software, incluso para usos comerciales, siempre que se mantengan el aviso de copyright y el texto de la licencia en las copias o partes sustanciales del software.
+
+MIT no exige pago, no obliga a publicar trabajos derivados como codigo abierto y no prohibe el uso comercial. Tampoco ofrece garantia: el software se entrega tal como esta.
+
+## Como visualizar
+
+Abre `index.html` localmente en un navegador o publica el repositorio con GitHub Pages. Las experiencias son estaticas y deben seguir funcionando sin etapa de build.
+
+## Directrices de documentacion
+
+El portugues brasileno es la fuente canonica de la documentacion. Al crear o cambiar documentos importantes, manten tambien versiones en ingles (`README.md`) y espanol (`LEEME.md`) cuando tenga sentido.

--- a/LEIAME.md
+++ b/LEIAME.md
@@ -1,0 +1,36 @@
+# MJDA: arquivo de experiencias interativas
+
+DOCS: [LEIAME.MD](LEIAME.md) / [README.MD](README.md) / [LEEME.MD](LEEME.md)
+
+Este repositorio preserva e organiza experiencias interativas criadas no Master em Jornalismo de Dados, Automacao e Data Storytelling (MJDA). Ele funciona como um arquivo publico do percurso no curso: pequenos protoartefatos de jornalismo de dados, visualizacao e narrativa interativa, publicados como paginas estaticas.
+
+## Experiencias
+
+- [Calculadora / timeline](calc/): calculadora de geracoes com navegacao horizontal e uma versao experimental em `calc/exp/`.
+- [Mapa](mapa/): visualizacao sobre casamentos LGBT por estado e genero.
+- [Quiz](quiz/): quiz visual sobre economia e PIB usando bandeiras e barras.
+- [Scroll](scroll/): narrativa em scroll sobre Google Phones.
+
+## Convencao do arquivo
+
+Este repositorio separa preservacao historica de novas iteracoes:
+
+- `codei-na-unha`: espaco de museu/preservacao do trabalho original feito no MJDA. Deve ser tratado como registro historico, com mudancas minimas e bem documentadas.
+- `v0` / `v1`: novas iteracoes assistidas por agentes, usadas para experimentar melhorias, reorganizar interfaces e testar caminhos sem apagar a autoria e o estado original.
+- `laboratelier`: destino futuro dos protoartefatos vivos, quando uma experiencia deixar de ser apenas arquivo do curso e passar a existir como laboratorio em evolucao.
+
+## Licenca
+
+A licenca atual do repositorio e [MIT](LICENSE).
+
+Em linguagem direta, ela permite usar, copiar, modificar, distribuir e vender copias deste software, inclusive em usos comerciais, desde que o aviso de copyright e o texto da licenca sejam mantidos nas copias ou partes substanciais do software.
+
+A MIT nao exige pagamento, nao obriga que trabalhos derivados sejam publicados como codigo aberto e nao proibe uso comercial. Ela tambem nao oferece garantia: o software e fornecido no estado em que esta.
+
+## Como visualizar
+
+Abra `index.html` localmente em um navegador ou publique o repositorio em GitHub Pages. As experiencias sao estaticas e devem continuar funcionando sem etapa de build.
+
+## Diretrizes de documentacao
+
+O pt-BR e a fonte canonica da documentacao. Ao criar ou alterar documentos importantes, mantenha tambem versoes em ingles (`README.md`) e espanhol (`LEEME.md`) quando fizer sentido.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# MJDA: interactive experiences archive
+
+DOCS: [LEIAME.MD](LEIAME.md) / [README.MD](README.md) / [LEEME.MD](LEEME.md)
+
+This repository preserves and organizes interactive experiences created during the Master in Data Journalism, Automation and Data Storytelling (MJDA). It works as a public archive of coursework: small data journalism, visualization and interactive storytelling proto-artifacts, published as static pages.
+
+## Experiences
+
+- [Calculator / timeline](calc/): generation calculator with horizontal navigation and an experimental version in `calc/exp/`.
+- [Map](mapa/): visualization about LGBT marriages by Brazilian state and gender.
+- [Quiz](quiz/): visual quiz about economics and GDP using flags and bars.
+- [Scroll](scroll/): scrolling story about Google Phones.
+
+## Archive convention
+
+This repository separates historical preservation from new iterations:
+
+- `codei-na-unha`: museum/preservation space for the original MJDA work. Treat it as a historical record, with minimal and clearly documented changes.
+- `v0` / `v1`: new agent-assisted iterations, used to try improvements, reorganize interfaces and test directions without erasing the original authorship and state.
+- `laboratelier`: future destination for living proto-artifacts, when an experience moves beyond coursework archive and becomes an evolving laboratory.
+
+## License
+
+The current repository license is [MIT](LICENSE).
+
+In plain language, it allows people to use, copy, modify, distribute and sell copies of this software, including for commercial use, as long as the copyright notice and license text are kept in copies or substantial portions of the software.
+
+MIT does not require payment, does not force derivative work to be open source and does not prohibit commercial use. It also provides no warranty: the software is provided as is.
+
+## How to view
+
+Open `index.html` locally in a browser or publish the repository through GitHub Pages. The experiences are static and should keep working without a build step.
+
+## Documentation guidelines
+
+Brazilian Portuguese is the canonical documentation source. When creating or changing important docs, also keep English (`README.md`) and Spanish (`LEEME.md`) versions when it makes sense.

--- a/index.html
+++ b/index.html
@@ -1,22 +1,68 @@
 <!DOCTYPE html>
-<html>
+<html lang="pt-BR">
 <head>
-    <title>Interaja com as minhas experiências feitas no MJDA 2021-2022 - Thiago 'Tode' Araujo - github.todearaujo.com</title>
-    <link rel="stylesheet" type="text/css" href="style.css">
+    <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Experiências interativas do MJDA - Thiago 'Tode' Araujo</title>
+    <meta name="description" content="Arquivo de experiências interativas feitas no Master em Jornalismo de Dados, Automação e Data Storytelling.">
+    <link rel="stylesheet" type="text/css" href="style.css">
 </head>
 <body>
-    <div class="container">
-        <div class="ola"><b>Olá!</b> Selecione uma das experiências para conhecer.</div>
-        <a href="https://www.todearaujo.com" target="_blank" class="link-todearaujo" style="color:#0F0F0F;">todearaujo.com/</a><a href="https://www.insper.edu.br/pos-graduacao/master-em-jornalismo-de-dados-automacao-e-data-storytelling/" class="link-mjda" target="_blank" style="color: #0F0F0F;"><b>mjda</b>/</a>
-        <select id="interactiveMenu" onchange="location = this.value;">
-            <option value="">👉🏻 interativo</option>
-            <option value="/mjda/calc/">✖️ calc</option>
-            <option value="/mjda/mapa/">🗺️ mapa</option>
-            <option value="/mjda/quiz/">🤔 quiz</option>
-            <option value="/mjda/scroll/">📱 scroll</option>
-        </select>
-        <div class="interativos">Em ✖️, calcule sua geração. 🗺️ com casamentos LGBT. No 🌎, quiz de economia e 📱 é a régua dos Google Phones.</div>
-    </div>
+    <header class="site-header">
+        <a href="https://www.todearaujo.com" target="_blank" rel="noreferrer">todearaujo.com</a>
+        <a href="https://www.insper.edu.br/pt/noticias/2023/12/quais-os-diferenciais-do-master-em-jornalismo-de-dados--automaca" target="_blank" rel="noreferrer">mjda</a>
+    </header>
+
+    <main>
+        <section class="intro" aria-labelledby="titulo">
+            <p class="kicker">arquivo / codei-na-unha / experiências</p>
+            <h1 id="titulo">Quatro jeitos de mexer com dados.</h1>
+            <div class="lede">
+                <p>Durante o meu Master em Jornalismo de Dados, Automação e Data Storytelling fomos desafiados pelos professores a pensar novas maneiras de apresentar informações para nossa audiência.</p>
+                <p>Os quatro formatos apresentados foram: quiz/teste; mapa; scrollytelling; calculadora.</p>
+                <p>Fique à vontade para explorar os protótipos e, se tiver comentários, me escreve no mjda(arroba)todearaujo.com.</p>
+            </div>
+        </section>
+
+        <section class="experiencias" aria-label="Tipos de experiência">
+            <a class="card calc" href="calc/">
+                <span class="numero">01</span>
+                <span class="tipo">calculadora / timeline</span>
+                <h2>De qual geração você é?</h2>
+                <p>Digite um ano de nascimento e atravesse uma linha do tempo de gerações.</p>
+                <span class="acao">entrar em calc</span>
+            </a>
+
+            <a class="card mapa" href="mapa/">
+                <span class="numero">02</span>
+                <span class="tipo">mapa</span>
+                <h2>Casamentos LGBT no Brasil</h2>
+                <p>Uma leitura geográfica dos dados por estado e gênero.</p>
+                <span class="acao">abrir mapa</span>
+            </a>
+
+            <a class="card quiz" href="quiz/">
+                <span class="numero">03</span>
+                <span class="tipo">quiz</span>
+                <h2>Quem tem o maior PIB?</h2>
+                <p>Um jogo visual com bandeiras, barras e economia mundial.</p>
+                <span class="acao">jogar quiz</span>
+            </a>
+
+            <a class="card scroll" href="scroll/">
+                <span class="numero">04</span>
+                <span class="tipo">scroll</span>
+                <h2>Linha do tempo dos Google Phones</h2>
+                <p>Role a página, veja os aparelhos e compare tamanhos na régua.</p>
+                <span class="acao">ver scroll</span>
+            </a>
+        </section>
+    </main>
+
+    <footer>
+        <a href="LEIAME.md">LEIAME</a>
+        <a href="README.md">README</a>
+        <a href="LEEME.md">LEEME</a>
+    </footer>
 </body>
 </html>

--- a/quiz/index.html
+++ b/quiz/index.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-    <div id="tode"><a href="http://github.todearaujo.com">@todearaujo</a></div>
+    <div id="tode"><a href="https://todearaujo.com/mjda">@todearaujo</a></div>
     <main>
         <section id="card">
             <p id="rightwrong"></p>

--- a/quiz/quiz.css
+++ b/quiz/quiz.css
@@ -9,7 +9,7 @@ main {
     width: 360px; 
     display: grid;
     text-align: center;
-    grid-template-rows: 160px 3fr 60px;
+    grid-template-rows: 130px 3fr 60px;
     transition: all 1s ease-in 0s;
     align-items: center;}
     
@@ -48,7 +48,8 @@ main {
     align-self: center;
     min-width: 320px;
     display: grid;
-    grid-template-rows: 90px 1fr;
+    grid-template-rows: auto 1fr;
+    gap: 16px;
 }
 
 #card {
@@ -71,8 +72,30 @@ main {
 
 #graph{
     display: grid;
-    grid-template-rows: 45vh 45px;
+    grid-template-rows: minmax(220px, 38vh) 45px;
     position: relative;
+}
+
+#question {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    line-height: 1.2;
+    margin: 0;
+}
+
+#question::after {
+    display: block;
+    order: 1;
+}
+
+#question[data-quest="q1"]::before {
+    content: "Selecione a bandeira para responder e aguarde...";
+    order: 2;
+    margin-top: 8px;
+    font-size: 13px;
+    font-weight: 400;
+    line-height: 1.3;
 }
 
 #rightwrong.show {transition: all 1s ease-in 7s;opacity: 1;}

--- a/style.css
+++ b/style.css
@@ -1,83 +1,266 @@
+/* Hallmark · pre-emit critique: P4 H4 E4 S4 R4 V4 */
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;700&display=swap');
 
+:root {
+    --font-base: 'IBM Plex Sans', Arial, sans-serif;
+    --color-paper: #f4efe7;
+    --color-ink: #0f0f0f;
+    --color-red: #cf2c2c;
+    --color-yellow: #ffeb3b;
+    --color-blue: #4f8cff;
+    --color-green: #43e27d;
+    --color-white: #ffffff;
+    --space-page: clamp(18px, 4vw, 54px);
+    --border-heavy: 4px solid var(--color-ink);
+    --shadow-hard: 10px 10px 0 var(--color-ink);
+}
+
+html,
 body {
-    font-family: 'IBM Plex Sans', Arial, sans-serif;
+    min-height: 100%;
     margin: 0;
-    padding: 0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
-    background-color: #CF2C2C;
+    overflow-x: clip;
 }
 
-.container {
-    text-align: center;
-    width: 90vw;
+body {
+    font-family: var(--font-base);
+    color: var(--color-ink);
+    background:
+        linear-gradient(110deg, transparent 0 62%, var(--color-yellow) 62% 100%),
+        var(--color-red);
 }
 
-.link-todearaujo, .link-mjda, .dropdown-label {
-    text-decoration: none;
+* {
+    box-sizing: border-box;
+}
+
+a {
     color: inherit;
-    font-size: 4vw;
-    display: inline-block;
 }
 
-.selecione{
-    color: #F2F2F2;
+.site-header,
+footer {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 18px var(--space-page);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0;
 }
 
-#interactiveMenu {
-    appearance: none; /* Remove o estilo padrão do navegador */
-    background: transparent; /* Fundo transparente */
-    border: none; /* Sem borda */
-    -webkit-appearance: none; /* Para navegadores baseados no WebKit */
-    -moz-appearance: none; /* Para Firefox */
-    color: white; /* Cor do texto */
-    font-size: 6vw; /* Mesmo tamanho que a linha */
-    cursor: pointer;
-    padding-right: 30px; /* Espaço para a setinha */
+.site-header a,
+footer a {
+    background: var(--color-paper);
+    border: 2px solid var(--color-ink);
+    padding: 8px 10px;
+    text-decoration: none;
+    box-shadow: 4px 4px 0 var(--color-ink);
 }
 
-#interactiveMenu::-ms-expand {
-    display: none; /* Esconde a seta padrão do IE */
+main {
+    width: min(1180px, calc(100% - (var(--space-page) * 2)));
+    margin: 0 auto;
+    padding: clamp(26px, 5vw, 74px) 0 44px;
 }
 
-.ola {
-    font-size: 2vw;
-    margin-bottom: 2vw;
+.intro {
+    display: grid;
+    grid-template-columns: minmax(0, 1.15fr) minmax(220px, 0.85fr);
+    gap: clamp(20px, 4vw, 54px);
+    align-items: end;
+    margin-bottom: clamp(28px, 5vw, 64px);
 }
 
-.interativos {
-    font-size: 1w;
-    color: white;
-    margin-top: 2vw;
+.kicker {
+    grid-column: 1 / -1;
+    width: max-content;
+    max-width: 100%;
+    margin: 0;
+    padding: 8px 10px;
+    color: var(--color-paper);
+    background: var(--color-ink);
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+h1 {
+    margin: 0;
+    font-size: clamp(3.1rem, 12vw, 9.2rem);
+    line-height: 0.86;
+    letter-spacing: 0;
+    overflow-wrap: anywhere;
+}
+
+.lede {
+    margin: 0;
+    padding: 18px;
+    border: var(--border-heavy);
+    background: var(--color-paper);
+    box-shadow: var(--shadow-hard);
+    font-size: clamp(1rem, 2vw, 1.35rem);
+    font-weight: 700;
+    line-height: 1.15;
+}
+
+.lede p {
+    margin: 0;
+}
+
+.lede p + p {
+    margin-top: 1em;
+}
+
+.experiencias {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: clamp(14px, 2vw, 22px);
+}
+
+.card {
+    min-height: 430px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 18px;
+    border: var(--border-heavy);
+    color: var(--color-ink);
+    background: var(--color-paper);
+    text-decoration: none;
+    box-shadow: var(--shadow-hard);
+    transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.card:hover,
+.card:focus-visible {
+    transform: translate(-4px, -4px) rotate(0deg);
+    box-shadow: 14px 14px 0 var(--color-ink);
+    outline: 0;
+}
+
+.card:active {
+    transform: translate(4px, 4px);
+    box-shadow: 4px 4px 0 var(--color-ink);
+}
+
+.card:nth-child(1) {
+    transform: rotate(-1.5deg);
+}
+
+.card:nth-child(2) {
+    transform: rotate(1deg);
+}
+
+.card:nth-child(3) {
+    transform: rotate(-0.75deg);
+}
+
+.card:nth-child(4) {
+    transform: rotate(1.5deg);
+}
+
+.calc {
+    background: var(--color-yellow);
+}
+
+.mapa {
+    background: var(--color-green);
+}
+
+.quiz {
+    background: var(--color-white);
+}
+
+.scroll {
+    background: var(--color-blue);
+}
+
+.numero,
+.tipo,
+.acao {
+    display: block;
+    width: fit-content;
+    padding: 6px 8px;
+    border: 2px solid var(--color-ink);
+    background: var(--color-paper);
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.numero {
+    font-size: 2.25rem;
+    line-height: 1;
+}
+
+.tipo {
+    font-size: 0.85rem;
+}
+
+.card h2 {
+    margin: auto 0 0;
+    font-size: clamp(1.6rem, 3vw, 2.4rem);
+    line-height: 0.95;
+    letter-spacing: 0;
+}
+
+.card p {
+    min-height: 78px;
+    margin: 0;
+    font-size: 1rem;
+    line-height: 1.22;
+}
+
+.acao {
+    margin-top: auto;
+    background: var(--color-ink);
+    color: var(--color-paper);
+}
+
+footer {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    padding-top: 0;
+}
+
+@media (max-width: 920px) {
+    .intro,
+    .experiencias {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .lede {
+        align-self: stretch;
+    }
+
+    .card {
+        min-height: 330px;
+    }
 }
 
 @media (max-width: 600px) {
-    .container {
-        width: 70vw;
-        text-align: left;
+    :root {
+        --shadow-hard: 6px 6px 0 var(--color-ink);
     }
 
-    .link-todearaujo, .link-mjda, .dropdown-label, #interactiveMenu {
-        font-size: 5vw; /* Tamanho de fonte ajustado para dispositivos móveis */
+    .site-header {
+        flex-direction: column;
+        align-items: flex-start;
     }
 
-    .link-todearaujo {
-        margin-top: 2rem;
-        display: block; /* Quebra de linha após cada link */
+    .intro,
+    .experiencias {
+        grid-template-columns: minmax(0, 1fr);
     }
 
-    #interactiveMenu {
-        font-size: 7vw;
-        padding-right: 10px; /* Ajuste no padding */
+    h1 {
+        font-size: clamp(3rem, 18vw, 5.2rem);
     }
 
-    .interativos, .ola {
-        margin-top: 2rem;;
-        font-size: 1.2rem;
+    .card {
+        min-height: 280px;
+    }
+
+    .card:nth-child(n) {
+        transform: none;
     }
 }
-
-


### PR DESCRIPTION
## Summary
- Adiciona a tríade de documentação `LEIAME.md` / `README.md` / `LEEME.md` com contexto do arquivo MJDA, convenção entre `codei-na-unha`, `v0`/`v1` e `laboratelier`, e orientações de uso
- Atualiza a página inicial com nova estrutura editorial, cards de navegação para as experiências e metadados básicos de acessibilidade/SEO
- Ajusta detalhes de apresentação em `quiz/` para melhorar a leitura do enunciado e corrigir o link do autor
- Reescreve a folha global com uma direção visual mais forte, responsiva e compatível com GitHub Pages estático

## Testing
- Not run (not requested)
- Validação feita por inspeção dos arquivos alterados e revisão da consistência da navegação/estilos estáticos