### PR TITLE
Mapa v1: zoom full-bleed até as bordas da moldura

### DIFF
--- a/mapa/v1/app.js
+++ b/mapa/v1/app.js
@@ -3,6 +3,17 @@ const rateFormatter = new Intl.NumberFormat("pt-BR", {
   minimumFractionDigits: 1,
   maximumFractionDigits: 1
 });
+const millionFormatter = new Intl.NumberFormat("pt-BR", { maximumFractionDigits: 1 });
+
+// População aproximada e arredondada para o mais próximo, ex.: "~4,3 milhões".
+const approxPop = (n) => {
+  if (n >= 1e6) {
+    const m = n / 1e6;
+    const r = m >= 10 ? Math.round(m) : Math.round(m * 10) / 10;
+    return `~${millionFormatter.format(r)} ${r === 1 ? "milhão" : "milhões"} de pessoas`;
+  }
+  return `~${formatter.format(Math.round(n / 1000))} mil pessoas`;
+};
 
 const stateById = new Map();
 let orderedStates = [];
@@ -77,35 +88,51 @@ const targetViewBoxFor = (path) => {
   const box = bboxInSvgSpace(path);
   if (!box) return null;
 
+  // Aspecto da área visível (a "tela" da moldura). O viewBox é forçado a casar
+  // com ele, então o estado preenche as bordas sem letterbox.
   const aspect = mapSvg.clientWidth && mapSvg.clientHeight
     ? mapSvg.clientWidth / mapSvg.clientHeight
     : fullViewBox.width / fullViewBox.height;
-  const stateMax = Math.max(box.width, box.height);
-  const fullMax = Math.max(fullViewBox.width, fullViewBox.height);
-  const stateShare = stateMax / fullMax;
-  const pad = stateShare < 0.06 ? 8.2 : stateShare < 0.12 ? 5.2 : 3.2;
-  const minWidth = fullViewBox.width * 0.18;
-  const minHeight = fullViewBox.height * 0.18;
-  const maxWidth = fullViewBox.width * 0.78;
-  const maxHeight = fullViewBox.height * 0.78;
 
-  let width = clamp(box.width * pad, minWidth, maxWidth);
-  let height = clamp(box.height * pad, minHeight, maxHeight);
+  // Folga em volta do estado: apertada nos grandes, um respiro a mais nos pequenos.
+  const stateShare = Math.max(box.width, box.height) / Math.max(fullViewBox.width, fullViewBox.height);
+  const pad = stateShare < 0.06 ? 1.7 : stateShare < 0.12 ? 1.35 : 1.15;
 
+  let width = box.width * pad;
+  let height = box.height * pad;
+
+  // Cresce o lado menor para casar o aspecto da moldura (preenche, não corta o estado).
   if (width / height > aspect) {
     height = width / aspect;
   } else {
     width = height * aspect;
   }
 
-  width = Math.min(width, fullViewBox.width);
-  height = Math.min(height, fullViewBox.height);
+  // Piso de zoom: evita aproximar demais estados minúsculos (DF, SE, AL, RJ).
+  const minHeight = fullViewBox.height * 0.34;
+  if (height < minHeight) {
+    height = minHeight;
+    width = height * aspect;
+  }
 
+  // Teto: nunca passa do mapa inteiro, preservando o aspecto ao bater no limite.
+  if (width > fullViewBox.width) {
+    width = fullViewBox.width;
+    height = width / aspect;
+  }
+  if (height > fullViewBox.height) {
+    height = fullViewBox.height;
+    width = height * aspect;
+  }
+
+  // Enviesa o enquadramento para cima: o card cobre a base da moldura, então o
+  // estado fica a ~36% da altura, na área livre acima dele. O piso em fullViewBox.y
+  // evita vazio acima do mapa; abaixo pode sobrar fundo (fica atrás do card).
   const centerX = box.x + box.width / 2;
   const centerY = box.y + box.height / 2;
   return {
     x: clamp(centerX - width / 2, fullViewBox.x, fullViewBox.x + fullViewBox.width - width),
-    y: clamp(centerY - height / 2, fullViewBox.y, fullViewBox.y + fullViewBox.height - height),
+    y: Math.max(centerY - height * 0.36, fullViewBox.y),
     width,
     height
   };
@@ -168,7 +195,7 @@ const selectState = (id) => {
   els.total.textContent = formatter.format(state.casamentos);
   els.men.textContent = formatter.format(state.homem);
   els.women.textContent = formatter.format(state.mulher);
-  els.note.textContent = `População est. em 2024: ${formatter.format(state.pop)} pessoas.`;
+  els.note.textContent = `População estimada em 2024: ${approxPop(state.pop)}.`;
 
   document.querySelectorAll(".step").forEach((step) => {
     step.classList.toggle("active", step.dataset.id === String(id));
@@ -206,6 +233,7 @@ const wireMap = () => {
   mapSvg = document.querySelector(".map svg");
   mapSvg?.removeAttribute("width");
   mapSvg?.removeAttribute("height");
+  mapSvg?.setAttribute("preserveAspectRatio", "xMidYMid slice");
   if (mapSvg) {
     fullViewBox = parseViewBox(mapSvg);
     currentViewBox = fullViewBox;

--- a/mapa/v1/index.html
+++ b/mapa/v1/index.html
@@ -9,7 +9,7 @@
   <title>Casou onde? v1</title>
   <meta name="description" content="Scrollytelling com mapa de casamentos entre pessoas do mesmo gênero no Brasil, por UF, de 2013 a 2024.">
   <meta property="og:image" content="../ogimage.png">
-  <link rel="stylesheet" href="style.css?v=20260621-map-zoom">
+  <link rel="stylesheet" href="style.css?v=20260622-fullbleed">
 </head>
 <body>
   <div class="device-frame">
@@ -74,6 +74,6 @@
     </div>
   </div>
 
-  <script src="app.js?v=20260621-map-zoom"></script>
+  <script src="app.js?v=20260622-fullbleed"></script>
 </body>
 </html>

--- a/mapa/v1/style.css
+++ b/mapa/v1/style.css
@@ -159,39 +159,28 @@ h1 {
 .story-shell {
   position: relative;
   z-index: 1;
-  display: grid;
-  width: min(1180px, calc(100% - 32px));
-  grid-template-columns: minmax(0, 1fr) minmax(290px, 420px);
-  gap: 48px;
+  width: 100%;
   margin: 0 auto;
 }
 
 .sticky-stage {
   position: sticky;
   top: 0;
-  display: flex;
   height: 100vh;
-  flex-direction: column;
-  justify-content: flex-start;
-  gap: 16px;
   overflow: hidden;
-  padding: 24px 0 0;
+  pointer-events: none;
 }
 
 .map {
-  flex: 0 0 auto;
-  align-self: start;
-  width: 100%;
+  position: absolute;
+  inset: 0;
   overflow: hidden;
-  border-radius: 10px;
 }
 
 .map svg {
   display: block;
   width: 100%;
-  height: auto;
-  max-height: min(44vh, 390px);
-  aspect-ratio: 44.6914 / 39.0226;
+  height: 100%;
   overflow: hidden;
 }
 
@@ -216,11 +205,19 @@ h1 {
 }
 
 .data-card {
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--paper) 94%, transparent);
-  padding: 16px;
-  box-shadow: 0 18px 48px rgb(54 33 22 / 0.12);
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: 12px;
+  z-index: 2;
+  border: 1px solid color-mix(in srgb, var(--line) 70%, transparent);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--paper) 84%, transparent);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  padding: 12px 14px;
+  box-shadow: 0 18px 48px rgb(54 33 22 / 0.18);
+  pointer-events: auto;
 }
 
 .data-card p {
@@ -238,17 +235,17 @@ h1 {
 }
 
 .data-card h2 {
-  margin: 0 0 12px;
-  font-size: clamp(1.7rem, 3.4vw, 2.65rem);
+  margin: 2px 0 10px;
+  font-size: clamp(1.45rem, 6vw, 2rem);
   line-height: 1;
 }
 
 .state-flag {
   display: block;
-  width: 82px;
-  max-height: 54px;
+  width: 56px;
+  max-height: 34px;
   object-fit: contain;
-  margin: 0 0 14px;
+  margin: 0 0 10px;
 }
 
 .state-flag[hidden] {
@@ -264,9 +261,9 @@ dl {
 }
 
 dl div {
-  min-height: 76px;
-  background: var(--paper);
-  padding: 12px;
+  min-height: 52px;
+  background: color-mix(in srgb, var(--paper) 90%, transparent);
+  padding: 8px 10px;
 }
 
 dt {
@@ -277,9 +274,15 @@ dt {
 }
 
 dd {
-  margin: 6px 0 0;
-  font-size: 1.35rem;
+  margin: 4px 0 0;
+  font-size: 1.12rem;
   font-weight: 900;
+}
+
+#state-note {
+  margin: 10px 0 0;
+  font-size: 0.76rem;
+  line-height: 1.3;
 }
 
 dd small {
@@ -383,40 +386,23 @@ dd small {
 
   .story-shell {
     display: block;
-    grid-template-columns: 1fr;
+    width: 100%;
     margin-top: 0;
   }
 
   .sticky-stage {
     top: clamp(42px, 8svh, 76px);
     z-index: 2;
-    display: grid;
     height: calc(100svh - clamp(42px, 8svh, 76px));
-    grid-template-rows: 55fr 45fr;
     min-height: 620px;
-    gap: 0;
     padding: 0;
-    pointer-events: none;
-    background: linear-gradient(180deg, var(--bg) 0%, color-mix(in srgb, var(--bg) 92%, transparent) 72%, transparent 100%);
-  }
-
-  .map {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding-top: clamp(0.75rem, 2svh, 1.5rem);
-  }
-
-  .map svg {
-    max-height: min(42svh, 360px);
-    opacity: 0.9;
   }
 
   .data-card {
-    align-self: start;
-    padding: 12px;
-    box-shadow: none;
-    pointer-events: auto;
+    left: 14px;
+    right: 14px;
+    bottom: 14px;
+    padding: 12px 14px;
   }
 
   .data-card h2 {
@@ -562,39 +548,23 @@ dd small {
 
   .story-shell {
     display: block;
+    width: 100%;
     margin-top: 0;
   }
 
   .sticky-stage {
     top: 0;
     z-index: 2;
-    display: grid;
     height: calc(90vh - 8.9vh);
-    grid-template-rows: 55fr 45fr;
     min-height: 0;
-    gap: 0;
     padding: 0;
-    pointer-events: none;
-    background: linear-gradient(180deg, var(--bg) 0%, color-mix(in srgb, var(--bg) 92%, transparent) 72%, transparent 100%);
-  }
-
-  .map {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding-top: clamp(0.75rem, 2vh, 1.5rem);
-  }
-
-  .map svg {
-    max-height: min(40vh, 340px);
-    opacity: 0.9;
   }
 
   .data-card {
-    align-self: start;
-    padding: 11px;
-    box-shadow: none;
-    pointer-events: auto;
+    left: 12px;
+    right: 12px;
+    bottom: 12px;
+    padding: 11px 13px;
   }
 
   .data-card h2 {


### PR DESCRIPTION
## O que muda

Reenquadra a experiência **`mapa/v1`** ("Casou onde?") para que o mapa preencha a tela do iPhone de borda a borda e o zoom de cada estado encha a moldura, em vez de ficar numa faixa horizontal com margens.

### `style.css` — mapa full-bleed
- Remove o `aspect-ratio` fixo e os caps de `max-height` que prendiam o mapa numa faixa.
- `.map svg` passa a preencher a moldura inteira (`inset: 0`).
- `.data-card` vira painel translúcido (`backdrop-filter: blur`) sobreposto na base, com conteúdo compactado.

### `app.js` — zoom e dados
- `preserveAspectRatio="xMidYMid slice"` para o SVG preencher sem letterbox.
- Cálculo de zoom reescrito: padding mais apertado + `viewBox` casando o aspecto da moldura. O clamp vertical foi solto para permitir fundo abaixo (que fica atrás do card) e um viés de ~36% que tira estados largos do Sudeste/Sul de trás do card.
- População exibida **aproximada e por extenso**, ex.: `~46 milhões de pessoas`.

### `index.html`
- Cache-bust das versões de CSS/JS.

## Escopo
Só a `mapa/v1` (3 arquivos). Não toca em `mapa/v0`, `mapa/codei-na-unha` nem nos dados de `mapa/shared/`.

## Verificação
Validado via Chromium headless em desktop (moldura de iPhone) e mobile (full-bleed), com estado largo (SP), gigante (AM), minúsculo (DF) e do sul (RS). Os valores reais do `viewBox` confirmaram o diagnóstico e a correção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sx9YVZJnE9i55YCy8dsnFw)_