### PR TITLE
Mapa v1: notas e footer no mesmo tamanho da nota do box de dados

### DIFF
--- a/mapa/v1/index.html
+++ b/mapa/v1/index.html
@@ -9,7 +9,7 @@
   <title>Bicha, tu casou? Onde? v1</title>
   <meta name="description" content="Scrollytelling com mapa de casamentos entre pessoas do mesmo gênero no Brasil, por UF, de 2013 a 2024.">
   <meta property="og:image" content="../ogimage.png">
-  <link rel="stylesheet" href="style.css?v=20260622-h1b">
+  <link rel="stylesheet" href="style.css?v=20260623-notas">
 </head>
 <body>
   <div class="device-frame">

--- a/mapa/v1/style.css
+++ b/mapa/v1/style.css
@@ -345,6 +345,7 @@ dd small {
 .source-note p {
   max-width: 760px;
   color: var(--muted);
+  font-size: 0.76rem;
   line-height: 1.6;
 }
 


### PR DESCRIPTION
Deixa as **Fontes e metodologia**, as **Notas** e a linha de **DOCS** do footer no mesmo tamanho (`0.76rem`) da frase que fecha o box de dados do estado (`#state-note`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xej2faREo1rKFVniX4gTW4)_