### PR TITLE
Mapa v1: full-bleed no mobile, H1, intro e créditos

### DIFF
--- a/mapa/v1/index.html
+++ b/mapa/v1/index.html
@@ -6,10 +6,10 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <title>Bicha, tu casou? Onde? v1</title>
+  <title>Bicha, tu casou onde? v1</title>
   <meta name="description" content="Scrollytelling com mapa de casamentos entre pessoas do mesmo gênero no Brasil, por UF, de 2013 a 2024.">
   <meta property="og:image" content="../ogimage.png">
-  <link rel="stylesheet" href="style.css?v=20260622-h1b">
+  <link rel="stylesheet" href="style.css?v=20260623-mobile">
 </head>
 <body>
   <div class="device-frame">
@@ -17,8 +17,9 @@
       <header class="opening">
         <nav><a href="../">/mapa</a> · <a href="../v0/">v0</a> · <a href="../codei-na-unha/">original</a></nav>
         <p class="eyebrow">v1 / mapa + scroll</p>
-        <h1>Bicha, tu casou? Onde?</h1>
-        <p>Deslize para cima e veja o ranking dos estados com mais casamentos entre pessoas do mesmo gênero<sup>1</sup> textual<sup>2</sup> jurídico<sup>3</sup>.</p>
+        <h1>Bicha, tu casou onde?</h1>
+        <p>Deslize para cima e veja o ranking dos estados por taxa de casamentos entre pessoas do mesmo gênero<sup>1</sup> textual<sup>2</sup> jurídico<sup>3</sup>, por 1 mi de hab.</p>
+        <p class="credits">Um interativo por <a href="https://todearaujo.com" target="_blank" rel="noreferrer">@todearaujo</a> &amp; Claude</p>
         <svg class="rings" aria-hidden="true" viewBox="0 0 260 150" role="img">
           <defs>
             <linearGradient id="ringGold" x1="0" x2="1" y1="0" y2="1">

--- a/mapa/v1/style.css
+++ b/mapa/v1/style.css
@@ -82,7 +82,18 @@ h1 {
   max-width: 840px;
   margin: 0;
   font-size: clamp(4rem, 14vw, 12rem);
-  line-height: 0.82;
+  line-height: 0.95;
+}
+
+.credits {
+  margin: 22px 0 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+.credits a {
+  color: #8b1450;
 }
 
 .opening > p:last-child {
@@ -426,9 +437,9 @@ dd small {
   }
 
   .sticky-stage {
-    top: clamp(42px, 8svh, 76px);
+    top: 0;
     z-index: 2;
-    height: calc(100svh - clamp(42px, 8svh, 76px));
+    height: 100svh;
     min-height: 620px;
     padding: 0;
   }
@@ -485,6 +496,10 @@ dd small {
   .story-shell,
   .source-note {
     width: min(calc(100% - 40px), 520px);
+  }
+
+  .story-shell {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Ajustes pós-revisão no iPhone

- **Full-bleed no mobile:** o mapa não sangrava até as bordas no iPhone — o breakpoint `<=520px` reimpunha largura limitada ao `.story-shell`. Agora ele vai a 100% e a `sticky-stage` encosta no topo: o mapa preenche as bordas.
- **H1:** vira "Bicha, tu casou onde?" com `line-height: 0.95` (estava apertado).
- **Intro corrigida:** explicita que o ranking é **por taxa**, **por 1 mi de hab.**
- **Créditos** no hero: "Um interativo por @todearaujo & Claude".

Escopo: só `mapa/v1` (`index.html`, `style.css`). Verificado via Chromium headless em viewport de iPhone 14 Pro Max (430×932) — mapa edge-to-edge no estado, hero ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sx9YVZJnE9i55YCy8dsnFw)_