### PR TITLE
Mapa v1: corrige espaço no pé no mobile (100dvh)

### DIFF
--- a/mapa/v1/index.html
+++ b/mapa/v1/index.html
@@ -9,7 +9,7 @@
   <title>Bicha, tu casou onde? v1</title>
   <meta name="description" content="Scrollytelling com mapa de casamentos entre pessoas do mesmo gênero no Brasil, por UF, de 2013 a 2024.">
   <meta property="og:image" content="../ogimage.png">
-  <link rel="stylesheet" href="style.css?v=20260623-mobile">
+  <link rel="stylesheet" href="style.css?v=20260623-dvh">
 </head>
 <body>
   <div class="device-frame">

--- a/mapa/v1/style.css
+++ b/mapa/v1/style.css
@@ -440,7 +440,7 @@ dd small {
   .sticky-stage {
     top: 0;
     z-index: 2;
-    height: 100svh;
+    height: 100dvh;
     min-height: 620px;
     padding: 0;
   }


### PR DESCRIPTION
## Corrige o espaço no pé (mobile / iOS)

No iOS, `100svh` é a altura da viewport com a barra do navegador **expandida**. Ao rolar e a barra encolher, a área visível fica maior que `svh`, e o `.data-card` (ancorado no fim do palco de `100svh`) sobrava acima do fim real da tela — o espaço que aparecia no Safari e no Chrome.

Troca a altura da `.sticky-stage` no breakpoint mobile de `100svh` para **`100dvh`** (dynamic viewport height), que acompanha a barra do navegador e mantém o card no fim da tela.

Não reproduzível em headless (sem barra dinâmica, `dvh = svh`); validação final no iPhone. Escopo: só `mapa/v1/style.css` (+ cache-bust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sx9YVZJnE9i55YCy8dsnFw)_