### PR TITLE
Mapa v1: colore as faixas (fundo do mapa + theme-color)

### DIFF
--- a/mapa/v1/index.html
+++ b/mapa/v1/index.html
@@ -9,7 +9,8 @@
   <title>Bicha, tu casou onde? v1</title>
   <meta name="description" content="Scrollytelling com mapa de casamentos entre pessoas do mesmo gênero no Brasil, por UF, de 2013 a 2024.">
   <meta property="og:image" content="../ogimage.png">
-  <link rel="stylesheet" href="style.css?v=20260623-dvh">
+  <meta name="theme-color" content="#e9e2f1">
+  <link rel="stylesheet" href="style.css?v=20260623-mapbg">
 </head>
 <body>
   <div class="device-frame">

--- a/mapa/v1/style.css
+++ b/mapa/v1/style.css
@@ -5,6 +5,7 @@
   --line: #d8c7ba;
   --paper: #fffaf4;
   --low: #eee7ff;
+  --map-bg: #e9e2f1;
   --high: #6e43b7;
   --active: #5c35a1;
   --gold: #f7d955;
@@ -186,6 +187,7 @@ h1 {
   position: absolute;
   inset: 0;
   overflow: hidden;
+  background: var(--map-bg);
 }
 
 .map svg {


### PR DESCRIPTION
## Colore as faixas no topo e no pé

As faixas creme que apareciam acima e abaixo do mapa no iOS eram áreas onde o **SVG é transparente**, deixando ver o fundo creme da página.

- **`--map-bg` (lavanda) no `.map`:** preenche as partes transparentes do SVG com o tom dos estados esmaecidos — o campo do mapa fica uniforme, sem o creme nas bordas.
- **`<meta name="theme-color">` lavanda:** tinge a barra do navegador (status bar / barra do Safari) no iOS para combinar.

Validado em headless (topo do mapa agora uniforme). O efeito no chrome do iOS confirma-se no aparelho. Escopo: `mapa/v1` (`style.css` + `index.html`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sx9YVZJnE9i55YCy8dsnFw)_