### PR TITLE
Mapa v1: edge-to-edge no iOS (viewport-fit=cover + safe-area-inset)

### DIFF
--- a/mapa/v1/index.html
+++ b/mapa/v1/index.html
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
@@ -10,7 +10,7 @@
   <meta name="description" content="Scrollytelling com mapa de casamentos entre pessoas do mesmo gênero no Brasil, por UF, de 2013 a 2024.">
   <meta property="og:image" content="../ogimage.png">
   <meta name="theme-color" content="#e9e2f1">
-  <link rel="stylesheet" href="style.css?v=20260623-mapbg">
+  <link rel="stylesheet" href="style.css?v=20260624-safearea">
 </head>
 <body>
   <div class="device-frame">

--- a/mapa/v1/style.css
+++ b/mapa/v1/style.css
@@ -351,7 +351,7 @@ dd small {
 }
 
 .source-note {
-  padding: 64px 0 80px;
+  padding: 64px 0 calc(80px + env(safe-area-inset-bottom));
   border-top: 1px solid var(--line);
 }
 
@@ -406,7 +406,7 @@ dd small {
 
   .opening {
     min-height: 100svh;
-    padding-top: 1.25rem;
+    padding-top: calc(1.25rem + env(safe-area-inset-top));
     padding-bottom: 0;
   }
 
@@ -450,7 +450,7 @@ dd small {
   .data-card {
     left: 14px;
     right: 14px;
-    bottom: 14px;
+    bottom: calc(14px + env(safe-area-inset-bottom));
     padding: 12px 14px;
   }
 


### PR DESCRIPTION
## Edge-to-edge real no iOS (safe areas)

As faixas creme que sobravam em cima e embaixo eram as **safe areas do iOS** (status bar / notch e home indicator). Por padrão o conteúdo web não entra nessas zonas — o navegador as preenche com o fundo da página (creme). Colorir o `.map` não bastava porque o conteúdo nem chegava lá.

Correção pela recomendação do WebKit/MDN:
- **`viewport-fit=cover`** no meta viewport → o conteúdo passa a ocupar a tela inteira, inclusive sob notch e home indicator. Com o fundo lavanda do mapa + `100dvh`, o mapa preenche as faixas.
- **`env(safe-area-inset-*)`** para proteger o que é crítico: `padding-top` do hero (nav/título sob a status bar), `bottom` do `.data-card` (acima do home indicator) e `padding` do rodapé.

Não validável em headless (`env()` = 0 sem device); confirmação no iPhone. Refs: [WebKit — Designing Websites for iPhone X](https://webkit.org/blog/7929/designing-websites-for-iphone-x/), [MDN — env()](https://developer.mozilla.org/en-US/docs/Web/CSS/env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sx9YVZJnE9i55YCy8dsnFw)_