### PR TITLE
Mapa v1: cor comparativa sempre, seleção só na borda

### DIFF
--- a/mapa/v1/app.js
+++ b/mapa/v1/app.js
@@ -24,7 +24,6 @@ let mapSvg = null;
 let fullViewBox = null;
 let currentViewBox = null;
 let zoomAnimation = null;
-let minIndice = 0;
 
 const els = {
   map: document.querySelector("#mapa"),
@@ -43,13 +42,6 @@ const lavenderFor = (indice) => {
   const light = 90 - Math.round(indice * 38);
   const saturation = 42 + Math.round(indice * 18);
   return `hsl(266 ${saturation}% ${light}%)`;
-};
-
-// Opacidade do estado em foco proporcional à taxa: maior taxa = 100%, menor = 50%.
-const activeFillOpacity = (state) => {
-  const span = 1 - minIndice;
-  const t = span > 0 ? (state.indice - minIndice) / span : 1;
-  return 0.5 + 0.5 * t;
 };
 
 const positionLabelFor = (index) => `${orderedStates.length - index}º de ${orderedStates.length}`;
@@ -270,10 +262,7 @@ const selectState = (id) => {
   if (!state) return;
 
   document.querySelectorAll(".map path").forEach((path) => {
-    const isActive = path.id === String(id);
-    path.classList.toggle("active", isActive);
-    path.classList.toggle("dimmed", !isActive);
-    path.style.fillOpacity = isActive ? String(activeFillOpacity(state)) : "0.96";
+    path.classList.toggle("active", path.id === String(id));
   });
 
   const path = document.getElementById(String(id));
@@ -363,7 +352,6 @@ const init = async () => {
   els.map.innerHTML = svg;
   orderedStates = data.estados;
   orderedStates.forEach((state) => stateById.set(String(state.ide), state));
-  minIndice = Math.min(...orderedStates.map((state) => state.indice));
 
   wireMap();
   buildSteps();

--- a/mapa/v1/index.html
+++ b/mapa/v1/index.html
@@ -10,7 +10,7 @@
   <meta name="description" content="Scrollytelling com mapa de casamentos entre pessoas do mesmo gênero no Brasil, por UF, de 2013 a 2024.">
   <meta property="og:image" content="../ogimage.png">
   <meta name="theme-color" content="#e9e2f1">
-  <link rel="stylesheet" href="style.css?v=20260624-safearea">
+  <link rel="stylesheet" href="style.css?v=20260624-choropleth">
 </head>
 <body>
   <div class="device-frame">
@@ -83,6 +83,6 @@
     </div>
   </div>
 
-  <script src="app.js?v=20260624-finale"></script>
+  <script src="app.js?v=20260624-choropleth"></script>
 </body>
 </html>

--- a/mapa/v1/style.css
+++ b/mapa/v1/style.css
@@ -200,21 +200,16 @@ h1 {
 .map path {
   stroke: #fff6ed;
   stroke-width: 180;
-  transition: fill 220ms ease, opacity 220ms ease, stroke 220ms ease, transform 220ms ease;
+  transition: stroke 220ms ease, stroke-width 220ms ease;
   transform-box: fill-box;
   transform-origin: center;
 }
 
-.map path.dimmed {
-  opacity: 0.22;
-}
-
+/* Selecionado: só a borda dourada acende; o preenchimento continua na cor
+   comparativa do mapa (coroplético por taxa). */
 .map path.active {
-  fill: var(--active);
-  opacity: 1;
   stroke: var(--gold);
   stroke-width: 780;
-  transform: none;
 }
 
 .data-card {


### PR DESCRIPTION
## Cor comparativa sempre; seleção só acende a borda

Antes, o estado em foco recebia uma **cor fixa** (`var(--active)`), então todos os selecionados ficavam iguais e perdia-se a comparação; e os vizinhos eram esmaecidos (`dimmed`), deixando o mapa com aparência uniforme.

Agora:
- **Todo estado mantém sua cor comparativa** do coroplético (`lavenderFor` pela taxa — mais claro = menor, mais escuro = maior).
- **Selecionar apenas acende a borda dourada**; o preenchimento não muda.
- Remove o *dimming* dos vizinhos — a gradação fica visível em volta do estado em foco.

Fica consistente com o finale nacional (mesmo esquema de cores). Validado em headless: Maranhão (claro, 27º) e DF (escuro, 1º), ambos com a borda dourada e a região ao redor no gradiente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sx9YVZJnE9i55YCy8dsnFw)_