### PR TITLE
Mapa v1: abertura no Brasil + dwell (tempo de leitura) e finale centralizado

### DIFF
--- a/mapa/v1/app.js
+++ b/mapa/v1/app.js
@@ -298,6 +298,15 @@ const updatePanels = (id) => {
   els.note.textContent = `${approxPop(state.pop)} era a população total estimada pelo IBGE em 2024.`;
 };
 
+// Remapeia a fração do trecho para criar "paradas": a câmera segura no estado nas
+// pontas (tempo de ler o card) e só viaja no miolo. Como ponta de um trecho e início
+// do seguinte caem no mesmo enquadramento, cada estado ganha uma faixa de permanência.
+const HOLD = 0.34;
+const travelEase = (t) => {
+  const u = clamp((t - HOLD) / (1 - 2 * HOLD), 0, 1);
+  return u * u * (3 - 2 * u);
+};
+
 const renderScroll = () => {
   scrollScheduled = false;
   if (!mapSvg || !cameras.length) return;
@@ -308,7 +317,7 @@ const renderScroll = () => {
   const a = cameras[i0];
   const b = cameras[i1];
   if (a && b) {
-    const camera = travelViewBox(a, b, index - i0, reducedMotion ? 0 : 1);
+    const camera = travelViewBox(a, b, travelEase(index - i0), reducedMotion ? 0 : 1);
     mapSvg.setAttribute("viewBox", viewBoxString(camera));
     currentViewBox = camera;
   }
@@ -326,20 +335,22 @@ const onScroll = () => {
   requestAnimationFrame(renderScroll);
 };
 
+const brasilStep = `
+      <article class="step" data-id="brasil">
+        <p class="rank">Panorama nacional</p>
+        <h3>Brasil</h3>
+      </article>
+    `;
+
 const buildSteps = () => {
-  els.steps.innerHTML = orderedStates
+  els.steps.innerHTML = brasilStep + orderedStates
     .map((state, index) => `
       <article class="step" data-id="${state.ide}">
         <p class="rank">${positionLabelFor(index)} · ${rateFormatter.format(perMillion(state))} por 1 mi hab.</p>
         <h3>${state.estado}</h3>
       </article>
     `)
-    .join("") + `
-      <article class="step" data-id="brasil">
-        <p class="rank">Panorama nacional</p>
-        <h3>Brasil</h3>
-      </article>
-    `;
+    .join("") + brasilStep;
 };
 
 els.flag.addEventListener("error", () => {

--- a/mapa/v1/index.html
+++ b/mapa/v1/index.html
@@ -83,6 +83,6 @@
     </div>
   </div>
 
-  <script src="app.js?v=20260624-travel"></script>
+  <script src="app.js?v=20260624-dwell"></script>
 </body>
 </html>


### PR DESCRIPTION
## Abertura no Brasil + permanência (dwell) por estado

Dois ajustes pedidos após testar no iPhone (incluindo o finale aparecendo deslocado).

**1. Abertura no Brasil** — adiciona um step "Brasil" no **início** (espelho do finale). A câmera começa no **país inteiro centralizado** e o 1º trecho de scroll faz o zoom-in até o Maranhão. Vira um arco: panorama → jornada pelo ranking → panorama.

**2. Permanência (dwell)** — remapeia a fração de cada trecho com easing `hold→travel→hold` (smoothstep, `HOLD=0.34`). Ao chegar num estado, a câmera **segura por uma faixa de scroll** (tempo de ler o card) e só viaja no miolo do trajeto. O pan+zoom-out de sobrevoo continua nas viagens longas.

**Corrige o desalinhamento do finale:** o país só ficava perfeitamente centralizado no ponto exato de chegada — parar um pouco antes mostrava a câmera no meio da viagem (vinda do DF, a leste), empurrando o mapa pra esquerda. Com o dwell, há uma faixa de permanência **centralizada** (`offsetX≈0`).

Validado em headless (430×932, smooth-scroll off): abertura com país centralizado (offsetX 0), finale centralizado (offsetX 0), e dwell confirmado (rolar +120px em SP não move a câmera).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sx9YVZJnE9i55YCy8dsnFw)_