### PR TITLE
Mapa v1: centralizar no continente, barra de progresso, card e copy

### DIFF
--- a/mapa/v1/app.js
+++ b/mapa/v1/app.js
@@ -5,14 +5,14 @@ const rateFormatter = new Intl.NumberFormat("pt-BR", {
 });
 const millionFormatter = new Intl.NumberFormat("pt-BR", { maximumFractionDigits: 1 });
 
-// População aproximada e abreviada, ex.: "~4,3 mi" ou "~636 mil".
+// População aproximada por extenso, ex.: "4,3 milhões", "1 milhão" ou "636 mil".
 const approxPop = (n) => {
   if (n >= 1e6) {
     const m = n / 1e6;
     const r = m >= 10 ? Math.round(m) : Math.round(m * 10) / 10;
-    return `~${millionFormatter.format(r)} mi`;
+    return `${millionFormatter.format(r)} ${r === 1 ? "milhão" : "milhões"}`;
   }
-  return `~${formatter.format(Math.round(n / 1000))} mil`;
+  return `${formatter.format(Math.round(n / 1000))} mil`;
 };
 
 // Taxa de nupcialidade por 1 milhão de habitantes (casamentos acumulados / pop * 1e6).
@@ -22,6 +22,7 @@ const stateById = new Map();
 let orderedStates = [];
 let mapSvg = null;
 let fullViewBox = null;
+let mainlandBox = null;
 let currentViewBox = null;
 
 const els = {
@@ -34,7 +35,8 @@ const els = {
   total: document.querySelector("#state-total"),
   men: document.querySelector("#state-men"),
   women: document.querySelector("#state-women"),
-  note: document.querySelector("#state-note")
+  note: document.querySelector("#state-note"),
+  progressFill: document.querySelector(".progress-fill")
 };
 
 const lavenderFor = (indice) => {
@@ -222,20 +224,37 @@ const focusIndex = () => {
 // Enquadramento do país inteiro: expande o viewBox do Brasil para o aspecto da
 // moldura (com folga), garantindo que todo o mapa caiba, com viés para cima para
 // não ficar atrás do card.
+// Caixa do continente: união das extensões robustas dos estados (ignora as ilhas
+// atlânticas, que esticam o viewBox do SVG e descentralizam o país).
+const computeMainlandBox = () => {
+  let x0 = Infinity, y0 = Infinity, x1 = -Infinity, y1 = -Infinity;
+  document.querySelectorAll(".map path").forEach((path) => {
+    if (!stateById.has(path.id)) return;
+    const e = robustExtentInSvgSpace(path);
+    if (!e) return;
+    x0 = Math.min(x0, e.x);
+    y0 = Math.min(y0, e.y);
+    x1 = Math.max(x1, e.x + e.width);
+    y1 = Math.max(y1, e.y + e.height);
+  });
+  return x0 === Infinity ? fullViewBox : { x: x0, y: y0, width: x1 - x0, height: y1 - y0 };
+};
+
 const countryViewBox = () => {
-  if (!fullViewBox || !mapSvg) return fullViewBox;
+  const base = mainlandBox || fullViewBox;
+  if (!base || !mapSvg) return fullViewBox;
   const aspect = mapSvg.clientWidth && mapSvg.clientHeight
     ? mapSvg.clientWidth / mapSvg.clientHeight
-    : fullViewBox.width / fullViewBox.height;
-  let width = fullViewBox.width * 1.08;
-  let height = fullViewBox.height * 1.08;
+    : base.width / base.height;
+  let width = base.width * 1.08;
+  let height = base.height * 1.08;
   if (width / height > aspect) {
     height = width / aspect;
   } else {
     width = height * aspect;
   }
-  const centerX = fullViewBox.x + fullViewBox.width / 2;
-  const centerY = fullViewBox.y + fullViewBox.height / 2;
+  const centerX = base.x + base.width / 2;
+  const centerY = base.y + base.height / 2;
   return { x: centerX - width / 2, y: centerY - height * 0.34, width, height };
 };
 
@@ -243,6 +262,7 @@ const countryViewBox = () => {
 // depende do aspecto da moldura.
 const computeCameras = () => {
   stepEls = Array.from(document.querySelectorAll(".step"));
+  mainlandBox = computeMainlandBox();
   cameras = stepEls.map((step) => {
     const id = step.dataset.id;
     if (id === "brasil") return countryViewBox();
@@ -272,11 +292,11 @@ const updatePanels = (id) => {
     els.rank.textContent = "Panorama nacional · 2013–2024";
     els.name.textContent = "Brasil";
     els.flag.hidden = true;
-    els.rate.textContent = rateFormatter.format((totals.casamentos / totals.pop) * 1e6);
+    els.rate.textContent = `~${formatter.format(Math.round((totals.casamentos / totals.pop) * 1e6))}`;
     els.total.textContent = formatter.format(totals.casamentos);
     els.men.textContent = formatter.format(totals.homem);
     els.women.textContent = formatter.format(totals.mulher);
-    els.note.textContent = `${approxPop(totals.pop)} era a população do país estimada pelo IBGE em 2024.`;
+    els.note.textContent = `Aprox. ${approxPop(totals.pop)} era a população do país segundo o IBGE em 2024.`;
     return;
   }
 
@@ -291,11 +311,11 @@ const updatePanels = (id) => {
   els.flag.hidden = false;
   els.flag.src = `flags/${state.uf}.svg`;
   els.flag.alt = `Bandeira de ${state.estado}`;
-  els.rate.textContent = rateFormatter.format(perMillion(state));
+  els.rate.textContent = `~${formatter.format(Math.round(perMillion(state)))}`;
   els.total.textContent = formatter.format(state.casamentos);
   els.men.textContent = formatter.format(state.homem);
   els.women.textContent = formatter.format(state.mulher);
-  els.note.textContent = `${approxPop(state.pop)} era a população total estimada pelo IBGE em 2024.`;
+  els.note.textContent = `Aprox. ${approxPop(state.pop)} era a população segundo o IBGE em 2024.`;
 };
 
 // Remapeia a fração do trecho para criar "paradas": a câmera segura no estado nas
@@ -320,6 +340,11 @@ const renderScroll = () => {
     const camera = travelViewBox(a, b, travelEase(index - i0), reducedMotion ? 0 : 1);
     mapSvg.setAttribute("viewBox", viewBoxString(camera));
     currentViewBox = camera;
+  }
+
+  const n = stepEls.length;
+  if (els.progressFill && n > 1) {
+    els.progressFill.style.width = `${Math.min((i0 + travelEase(index - i0)) / (n - 1), 1) * 100}%`;
   }
 
   const nearest = stepEls[Math.round(index)];

--- a/mapa/v1/index.html
+++ b/mapa/v1/index.html
@@ -10,7 +10,7 @@
   <meta name="description" content="Scrollytelling com mapa de casamentos entre pessoas do mesmo gênero no Brasil, por UF, de 2013 a 2024.">
   <meta property="og:image" content="../ogimage.png">
   <meta name="theme-color" content="#e9e2f1">
-  <link rel="stylesheet" href="style.css?v=20260624-choropleth">
+  <link rel="stylesheet" href="style.css?v=20260624-card">
 </head>
 <body>
   <div class="device-frame">
@@ -19,7 +19,8 @@
         <nav><a href="../">/mapa</a> · <a href="../v0/">v0</a> · <a href="../codei-na-unha/">original</a></nav>
         <p class="eyebrow">v1 / mapa + scroll</p>
         <h1>Bicha, tu casou onde?</h1>
-        <p>Deslize para cima e veja o ranking dos estados por taxa de casamentos homoafetivos por 1 mi de habitantes.</p>
+        <p class="lede">Deslize para cima e conheça o ranking dos estados onde aconteceram mais casamentos homoafetivos, somados entre 2013 e 2024.</p>
+        <p class="legend">Para te guiar pelo passeio no mapa: quanto mais escuro o estado, maior a taxa de casamentos por 1 milhão de habitantes.</p>
         <p class="credits">Um interativo por <a href="https://todearaujo.com" target="_blank" rel="noreferrer">@todearaujo</a> &amp; Claude</p>
         <svg class="rings" aria-hidden="true" viewBox="0 0 260 150" role="img">
           <defs>
@@ -38,20 +39,13 @@
 
       <main class="story-shell">
         <aside class="sticky-stage" aria-label="Mapa e quadro de dados">
+          <div class="progress" aria-hidden="true"><span class="progress-fill"></span></div>
           <div id="mapa" class="map"></div>
           <section class="data-card" aria-live="polite">
+            <img id="state-flag" class="state-flag" alt="">
             <p id="rank-label">Carregando...</p>
             <h2 id="state-name"></h2>
-            <img id="state-flag" class="state-flag" alt="">
             <dl>
-              <div>
-                <dt>Taxa</dt>
-                <dd><span id="state-rate">--</span><small>/1 mi hab.</small></dd>
-              </div>
-              <div>
-                <dt>Total</dt>
-                <dd id="state-total">--</dd>
-              </div>
               <div>
                 <dt>Homens</dt>
                 <dd id="state-men">--</dd>
@@ -59,6 +53,14 @@
               <div>
                 <dt>Mulheres</dt>
                 <dd id="state-women">--</dd>
+              </div>
+              <div>
+                <dt>Total</dt>
+                <dd id="state-total">--</dd>
+              </div>
+              <div class="cell-taxa">
+                <dt>Taxa</dt>
+                <dd><span id="state-rate">--</span><small>/1 mi hab.</small></dd>
               </div>
             </dl>
             <p id="state-note"></p>
@@ -72,6 +74,7 @@
         <section class="note-block">
           <h2>Fontes e metodologia</h2>
           <p>SIDRA/IBGE tabela 4406, variáveis 4373 e 4374, por UF e ano, acumuladas de 2013 a 2024. População: SIDRA/IBGE tabela 6579, variável 9324, ano 2024. A ordenação usa casamentos acumulados por 1 milhão de habitantes.</p>
+          <p>Contamos casamentos registrados em cartório (por lugar de registro), somados no período — não casais atualmente existentes. Os números não descontam divórcios, viuvez ou mudança de estado.</p>
         </section>
 
         <section class="note-block">
@@ -83,6 +86,6 @@
     </div>
   </div>
 
-  <script src="app.js?v=20260624-dwell"></script>
+  <script src="app.js?v=20260624-card"></script>
 </body>
 </html>

--- a/mapa/v1/style.css
+++ b/mapa/v1/style.css
@@ -97,12 +97,20 @@ h1 {
   color: #8b1450;
 }
 
-.opening > p:last-child {
+.lede {
   max-width: 660px;
   margin: 28px 0 0;
   color: var(--muted);
   font-size: clamp(1.2rem, 2.6vw, 1.8rem);
   line-height: 1.35;
+}
+
+.legend {
+  max-width: 560px;
+  margin: 16px 0 0;
+  color: var(--muted);
+  font-size: clamp(0.95rem, 2vw, 1.15rem);
+  line-height: 1.4;
 }
 
 .rings {
@@ -249,11 +257,26 @@ h1 {
 }
 
 .state-flag {
+  position: absolute;
+  top: 14px;
+  right: 14px;
   display: block;
   width: 56px;
   max-height: 34px;
   object-fit: contain;
-  margin: 0 0 10px;
+  margin: 0;
+}
+
+/* reserva espaço para a bandeira só quando ela está visível (não no Brasil) */
+.data-card:has(#state-flag:not([hidden])) #rank-label,
+.data-card:has(#state-flag:not([hidden])) h2 {
+  padding-right: 64px;
+}
+
+.cell-taxa dt,
+.cell-taxa dd,
+.cell-taxa small {
+  color: var(--active);
 }
 
 .state-flag[hidden] {
@@ -298,6 +321,24 @@ dd small {
   color: var(--muted);
   font-size: 0.78rem;
   font-weight: 700;
+}
+
+.progress {
+  position: absolute;
+  top: env(safe-area-inset-top);
+  left: 0;
+  right: 0;
+  z-index: 4;
+  height: 3px;
+  background: color-mix(in srgb, var(--ink) 12%, transparent);
+  pointer-events: none;
+}
+
+.progress-fill {
+  display: block;
+  width: 0;
+  height: 100%;
+  background: var(--gold);
 }
 
 .steps {
@@ -569,10 +610,15 @@ dd small {
     font-size: clamp(2.3rem, 6.2vh, 4.6rem);
   }
 
-  .opening > p:last-child {
+  .lede {
     margin-top: 16px;
     font-size: clamp(0.86rem, 1.7vh, 1rem);
     line-height: 1.25;
+  }
+
+  .legend {
+    margin-top: 10px;
+    font-size: clamp(0.78rem, 1.5vh, 0.95rem);
   }
 
   .rings {


### PR DESCRIPTION
## Centralizar no continente + barra de progresso + card + copy

**Centralização do Brasil (início e fim).** O `viewBox` do `bruf.svg` inclui as ilhas atlânticas (Trindade/ES, Fernando de Noronha, São Pedro e São Paulo), então centralizar nele empurrava o continente pra esquerda. Agora `countryViewBox()` usa a **caixa do continente** = união das extensões robustas dos 27 estados (`computeMainlandBox`, reusa `robustExtentInSvgSpace`). Centro vai de -51,6 (com ilhas) para -54,3 (continente).

**Barra de progresso** no topo da `.sticky-stage`: largura = progresso *eased* — avança nas viagens e segura no dwell (espelha a câmera), dando noção de quanto falta. Dourada, respeita `safe-area-inset-top`.

**Card:**
- Bandeira no **canto superior direito** (espaço reservado via `:has()`, só quando há bandeira — não no Brasil).
- Quadrantes invertidos: **Homens · Mulheres · Total · Taxa**.
- **Taxa em roxo** (`--active`) e **arredondada com ~** (ex.: `~344`).
- Nota: "**Aprox. X milhões era a população segundo o IBGE em 2024**".

**Metodologia (honesta):** nota no rodapé esclarecendo que são **casamentos registrados** (por lugar de registro), somados — **não casais atualmente existentes**, sem descontar divórcios/viuvez/mudança. (Decisão: manter a métrica acumulada; ranking inalterado.)

**Abertura:** copy nova (lede + legenda do coroplético "mais escuro = maior taxa"), período **2013–2024** (corrige typo "2014").

Validado em headless (430×932): país centralizado no continente (centro ≈ -54,3), card novo, taxa `~344`/roxo, barra a 100% no finale, sem erros de JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sx9YVZJnE9i55YCy8dsnFw)_