### PR TITLE
Mapa v1: barra de progresso mais grossa (16px)

### DIFF
--- a/mapa/v1/index.html
+++ b/mapa/v1/index.html
@@ -10,7 +10,7 @@
   <meta name="description" content="Scrollytelling com mapa de casamentos entre pessoas do mesmo gênero no Brasil, por UF, de 2013 a 2024.">
   <meta property="og:image" content="../ogimage.png">
   <meta name="theme-color" content="#e9e2f1">
-  <link rel="stylesheet" href="style.css?v=20260624-card">
+  <link rel="stylesheet" href="style.css?v=20260624-bar16">
 </head>
 <body>
   <div class="device-frame">

--- a/mapa/v1/style.css
+++ b/mapa/v1/style.css
@@ -329,7 +329,7 @@ dd small {
   left: 0;
   right: 0;
   z-index: 4;
-  height: 3px;
+  height: 16px;
   background: color-mix(in srgb, var(--ink) 12%, transparent);
   pointer-events: none;
 }


### PR DESCRIPTION
Engrossa a barra de progresso de **3px → 16px**, a pedido. Só `style.css` (+ bump de cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sx9YVZJnE9i55YCy8dsnFw)_