### PR TITLE
[codex] Ajusta layout da calculadora v0

### DIFF
--- a/calc/v0/css/app.css
+++ b/calc/v0/css/app.css
@@ -416,13 +416,14 @@ button:active:not(:disabled) {
 
 .birth-marker strong {
   position: absolute;
-  top: calc(var(--space-sm) * -1);
-  left: clamp(8.5rem, 24vw, 18rem);
+  top: calc(var(--space-xs) * -1);
+  left: clamp(7.2rem, 18vw, 13rem);
   background: var(--color-paper-2);
-  font-size: var(--text-sm);
+  font-size: clamp(0.56rem, 1.1vw, 0.68rem);
   line-height: 1;
-  padding: var(--space-2xs) var(--space-xs);
+  padding: var(--space-3xs) var(--space-2xs);
   text-transform: uppercase;
+  white-space: nowrap;
 }
 
 .panel-result {

--- a/calc/v0/index.html
+++ b/calc/v0/index.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Calculadora de gerações com linha do tempo e contexto histórico.">
   <meta property="og:image" content="../ogimage.png">
   <link rel="shortcut icon" href="../../favicon.ico" type="image/x-icon">
-  <link rel="stylesheet" href="css/app.css?v=20260622f">
+  <link rel="stylesheet" href="css/app.css?v=20260624a">
 </head>
 <body>
   <main id="app" class="swipe-shell" aria-label="Calculadora de gerações em três etapas">
@@ -22,7 +22,7 @@
       <form id="birth-form" class="birth-card" novalidate>
         <label for="ano-nascimento">Ano de nascimento</label>
         <div class="birth-row">
-          <input id="ano-nascimento" name="ano-nascimento" pattern="[0-9]{4}" minlength="4" maxlength="4" inputmode="numeric" autocomplete="bday-year" aria-describedby="entrada-ajuda" title="Insira 4 dígitos">
+          <input id="ano-nascimento" name="ano-nascimento" pattern="[0-9]{4}" minlength="4" maxlength="4" inputmode="numeric" autocomplete="bday-year" placeholder="AAAA" aria-describedby="entrada-ajuda" title="Insira 4 dígitos">
           <button id="calcular" type="submit">Calcular</button>
         </div>
         <p id="entrada-ajuda" class="helper">Use um ano entre 1883 e 2025.</p>
@@ -32,9 +32,9 @@
     <section id="grafico" class="panel panel-timeline" aria-labelledby="timeline-titulo">
       <div class="timeline-copy">
         <p class="stage">02 / linha do tempo</p>
-        <h2 id="timeline-titulo">Você no recorte.</h2>
-        <p>As faixas mostram o tamanho relativo de cada geração. Depois do cálculo, seu ano aparece como uma régua atravessando o período.</p>
-        <button id="ver-resultado" type="button" disabled>Ver resultado</button>
+        <h2 id="timeline-titulo">Seu resultado</h2>
+        <p>Cada faixa de anos corresponde a uma geração. Seu resultado está destacado com uma linha.</p>
+        <button id="ver-resultado" type="button" disabled>Veja mais infos</button>
       </div>
 
       <div class="timeline-board" aria-live="polite">


### PR DESCRIPTION
## O que mudou

- Adiciona placeholder `AAAA` ao campo de ano de nascimento.
- Atualiza o texto da etapa de resultado e o CTA para refletir melhor a navegação.
- Reduz o selo `SEU NASCIMENTO` na timeline para liberar o nome da geração destacada.
- Atualiza o cache-buster do CSS da calculadora v0.

## Impacto

A experiência da `/calc/v0/` fica mais clara visualmente e com menos sobreposição na timeline depois do cálculo.

## Validação

- Conferi `http://localhost:4173/calc/v0/` via servidor estático local.
- Verifiquei que o HTML servido contém os textos atualizados e o novo CSS versionado.