### PR TITLE
mapa/v1: frame fixo 420px + glass simples nos cells

### DIFF
--- a/mapa/v1/index.html
+++ b/mapa/v1/index.html
@@ -11,7 +11,7 @@
   <meta property="og:image" content="../ogimage.png">
   <meta name="theme-color" content="#e9e2f1">
   <link rel="shortcut icon" href="../../favicon.ico" type="image/x-icon">
-  <link rel="stylesheet" href="style.css?v=20260624-glasscell">
+  <link rel="stylesheet" href="style.css?v=20260624-glassmap">
 </head>
 <body>
   <div class="device-frame">

--- a/mapa/v1/index.html
+++ b/mapa/v1/index.html
@@ -11,7 +11,7 @@
   <meta property="og:image" content="../ogimage.png">
   <meta name="theme-color" content="#e9e2f1">
   <link rel="shortcut icon" href="../../favicon.ico" type="image/x-icon">
-  <link rel="stylesheet" href="style.css?v=20260624-glassmap">
+  <link rel="stylesheet" href="style.css?v=20260625-frame420">
 </head>
 <body>
   <div class="device-frame">

--- a/mapa/v1/index.html
+++ b/mapa/v1/index.html
@@ -11,7 +11,7 @@
   <meta property="og:image" content="../ogimage.png">
   <meta name="theme-color" content="#e9e2f1">
   <link rel="shortcut icon" href="../../favicon.ico" type="image/x-icon">
-  <link rel="stylesheet" href="style.css?v=20260624-glassdl">
+  <link rel="stylesheet" href="style.css?v=20260624-glasscell">
 </head>
 <body>
   <div class="device-frame">

--- a/mapa/v1/style.css
+++ b/mapa/v1/style.css
@@ -228,7 +228,9 @@ h1 {
   z-index: 2;
   border-radius: 18px;
   border: 1px solid rgba(255, 255, 255, 0.55);
-  background: transparent;
+  background: color-mix(in srgb, var(--paper) 58%, transparent);
+  -webkit-backdrop-filter: blur(24px) saturate(200%) brightness(1.08);
+  backdrop-filter: blur(24px) saturate(200%) brightness(1.08);
   padding: 12px 14px;
   box-shadow:
     inset 0 2px 0 rgba(255, 255, 255, 0.65),
@@ -239,22 +241,7 @@ h1 {
   pointer-events: auto;
 }
 
-/* frost layer — behind the content, blurs the map (parent owns no filter,
-   so the inner cells can sample the map for their own glass) */
 .data-card::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  z-index: -1;
-  border-radius: inherit;
-  background: color-mix(in srgb, var(--paper) 50%, transparent);
-  -webkit-backdrop-filter: blur(24px) saturate(200%) brightness(1.08);
-  backdrop-filter: blur(24px) saturate(200%) brightness(1.08);
-  pointer-events: none;
-}
-
-/* sheen highlight — on top of the frost */
-.data-card::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -318,24 +305,22 @@ h1 {
 dl {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 6px;
+  gap: 1px;
   margin: 0;
-  background: transparent;
+  background: var(--line);
 }
 
 dl div {
   position: relative;
   min-height: 52px;
   padding: 8px 10px;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.16);
-  -webkit-backdrop-filter: blur(6px) saturate(180%) brightness(1.12);
-  backdrop-filter: blur(6px) saturate(180%) brightness(1.12);
-  border: 1px solid rgba(255, 255, 255, 0.55);
+  background: color-mix(in srgb, var(--paper) 45%, transparent);
+  -webkit-backdrop-filter: blur(10px) saturate(160%) brightness(1.06);
+  backdrop-filter: blur(10px) saturate(160%) brightness(1.06);
+  border: 1px solid rgba(255, 255, 255, 0.45);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.7),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.05),
-    0 2px 8px rgba(0, 0, 0, 0.08);
+    inset 0 1px 0 rgba(255, 255, 255, 0.55),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.04);
   overflow: hidden;
 }
 
@@ -345,8 +330,8 @@ dl div::before {
   inset: 0;
   background: linear-gradient(
     150deg,
-    rgba(255, 255, 255, 0.4) 0%,
-    rgba(255, 255, 255, 0) 60%
+    rgba(255, 255, 255, 0.18) 0%,
+    rgba(255, 255, 255, 0) 55%
   );
   pointer-events: none;
 }
@@ -607,8 +592,7 @@ dd small {
 
   .device-frame {
     position: relative;
-    width: min(60vh, calc(100vw - 40px), 420px);
-    max-width: 90vw;
+    width: 420px;
     height: 90vh;
     max-height: calc(100vh - 32px);
     aspect-ratio: 460 / 690;

--- a/mapa/v1/style.css
+++ b/mapa/v1/style.css
@@ -314,13 +314,12 @@ dl div {
   position: relative;
   min-height: 52px;
   padding: 8px 10px;
-  background: color-mix(in srgb, var(--paper) 45%, transparent);
-  -webkit-backdrop-filter: blur(10px) saturate(160%) brightness(1.06);
-  backdrop-filter: blur(10px) saturate(160%) brightness(1.06);
-  border: 1px solid rgba(255, 255, 255, 0.45);
+  background: rgba(255, 255, 255, 0.68);
+  border: 1px solid rgba(255, 255, 255, 0.85);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.55),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.04);
+    inset 0 1px 0 rgba(255, 255, 255, 0.95),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.05),
+    0 2px 6px rgba(0, 0, 0, 0.06);
   overflow: hidden;
 }
 
@@ -330,8 +329,8 @@ dl div::before {
   inset: 0;
   background: linear-gradient(
     150deg,
-    rgba(255, 255, 255, 0.18) 0%,
-    rgba(255, 255, 255, 0) 55%
+    rgba(255, 255, 255, 0.45) 0%,
+    rgba(255, 255, 255, 0) 60%
   );
   pointer-events: none;
 }
@@ -592,7 +591,7 @@ dd small {
 
   .device-frame {
     position: relative;
-    width: min(60vh, calc(100vw - 40px));
+    width: min(60vh, calc(100vw - 40px), 420px);
     max-width: 90vw;
     height: 90vh;
     max-height: calc(100vh - 32px);

--- a/mapa/v1/style.css
+++ b/mapa/v1/style.css
@@ -228,9 +228,7 @@ h1 {
   z-index: 2;
   border-radius: 18px;
   border: 1px solid rgba(255, 255, 255, 0.55);
-  background: color-mix(in srgb, var(--paper) 58%, transparent);
-  -webkit-backdrop-filter: blur(24px) saturate(200%) brightness(1.08);
-  backdrop-filter: blur(24px) saturate(200%) brightness(1.08);
+  background: transparent;
   padding: 12px 14px;
   box-shadow:
     inset 0 2px 0 rgba(255, 255, 255, 0.65),
@@ -241,7 +239,22 @@ h1 {
   pointer-events: auto;
 }
 
+/* frost layer — behind the content, blurs the map (parent owns no filter,
+   so the inner cells can sample the map for their own glass) */
 .data-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  background: color-mix(in srgb, var(--paper) 50%, transparent);
+  -webkit-backdrop-filter: blur(24px) saturate(200%) brightness(1.08);
+  backdrop-filter: blur(24px) saturate(200%) brightness(1.08);
+  pointer-events: none;
+}
+
+/* sheen highlight — on top of the frost */
+.data-card::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -305,21 +318,24 @@ h1 {
 dl {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1px;
+  gap: 6px;
   margin: 0;
-  background: var(--line);
+  background: transparent;
 }
 
 dl div {
   position: relative;
   min-height: 52px;
   padding: 8px 10px;
-  background: rgba(255, 255, 255, 0.68);
-  border: 1px solid rgba(255, 255, 255, 0.85);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.16);
+  -webkit-backdrop-filter: blur(6px) saturate(180%) brightness(1.12);
+  backdrop-filter: blur(6px) saturate(180%) brightness(1.12);
+  border: 1px solid rgba(255, 255, 255, 0.55);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.95),
+    inset 0 1px 0 rgba(255, 255, 255, 0.7),
     inset 0 -1px 0 rgba(0, 0, 0, 0.05),
-    0 2px 6px rgba(0, 0, 0, 0.06);
+    0 2px 8px rgba(0, 0, 0, 0.08);
   overflow: hidden;
 }
 
@@ -329,7 +345,7 @@ dl div::before {
   inset: 0;
   background: linear-gradient(
     150deg,
-    rgba(255, 255, 255, 0.45) 0%,
+    rgba(255, 255, 255, 0.4) 0%,
     rgba(255, 255, 255, 0) 60%
   );
   pointer-events: none;


### PR DESCRIPTION
## O que muda

- **Frame 420px fixo** no desktop — sem clamp, sem `min()`, sem `max-width` extra
- **Glass simples** de volta: `.data-card` translúcida + `dl div` translúcida por cima — duas caixas empilhadas, sem pseudo-elementos desnecessários

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFXfkpY2V4D2X2T8zcZnXD)_