### PR TITLE
Update iPhone 15 frame colors to orange gradient theme

### DIFF
--- a/mapa/v1/iphone-15-frame.svg
+++ b/mapa/v1/iphone-15-frame.svg
@@ -1,14 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="430" height="852" viewBox="0 0 430 852" fill="none">
   <defs>
     <linearGradient id="edge" x1="32" x2="398" y1="20" y2="832" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#fffaf4"/>
-      <stop offset=".48" stop-color="#e6d9cd"/>
-      <stop offset="1" stop-color="#fff8f0"/>
+      <stop offset="0" stop-color="#FFBB66"/>
+      <stop offset=".48" stop-color="#FF9500"/>
+      <stop offset="1" stop-color="#FFA855"/>
     </linearGradient>
     <linearGradient id="bezel" x1="48" x2="382" y1="34" y2="818" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#fffdf9"/>
-      <stop offset=".5" stop-color="#f5eee7"/>
-      <stop offset="1" stop-color="#e8dbcf"/>
+      <stop offset="0" stop-color="#FFB844"/>
+      <stop offset=".5" stop-color="#FF9A00"/>
+      <stop offset="1" stop-color="#FF8C00"/>
     </linearGradient>
     <filter id="shadow" x="0" y="-8" width="430" height="896" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
       <feDropShadow dx="0" dy="16" stdDeviation="24" flood-color="#2e2119" flood-opacity=".12"/>
@@ -20,10 +20,10 @@
   </defs>
   <g mask="url(#screen-hole)">
     <rect x="28" y="10" width="374" height="832" rx="48" fill="url(#edge)" filter="url(#shadow)"/>
-    <rect x="36" y="18" width="358" height="816" rx="42" fill="#fffaf4"/>
+    <rect x="36" y="18" width="358" height="816" rx="42" fill="#FFAA44"/>
     <path d="M78 27h274c19 0 34 15 34 34v730c0 19-15 34-34 34H78c-19 0-34-15-34-34V61c0-19 15-34 34-34Zm8 16c-16 0-29 13-29 29v708c0 16 13 29 29 29h258c16 0 29-13 29-29V72c0-16-13-29-29-29H86Z" fill="url(#bezel)" fill-rule="evenodd" clip-rule="evenodd"/>
-    <rect x="199" y="42" width="32" height="4" rx="2" fill="#ddcec1" opacity=".8"/>
-    <path d="M28 174c-6 0-10 4-10 10v74c0 6 4 10 10 10v-94Z" fill="#d7c5b8"/>
-    <path d="M402 224c6 0 10 4 10 10v118c0 6-4 10-10 10V224Z" fill="#d7c5b8"/>
+    <rect x="199" y="42" width="32" height="4" rx="2" fill="#FF8833" opacity=".8"/>
+    <path d="M28 174c-6 0-10 4-10 10v74c0 6 4 10 10 10v-94Z" fill="#FF7700"/>
+    <path d="M402 224c6 0 10 4 10 10v118c0 6-4 10-10 10V224Z" fill="#FF7700"/>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
Updated the iPhone 15 frame SVG to use a warm orange color gradient instead of the previous beige/tan palette. This change affects all gradient definitions and fill colors throughout the device frame.

## Key Changes
- **Edge gradient**: Changed from beige tones (#fffaf4, #e6d9cd, #fff8f0) to orange tones (#FFBB66, #FF9500, #FFA855)
- **Bezel gradient**: Updated from light tan/brown (#fffdf9, #f5eee7, #e8dbcf) to orange shades (#FFB844, #FF9A00, #FF8C00)
- **Screen background**: Changed from #fffaf4 to #FFAA44
- **Notch/speaker elements**: Updated from gray-brown (#ddcec1) to orange (#FF8833)
- **Side button areas**: Changed from taupe (#d7c5b8) to bright orange (#FF7700)

## Implementation Details
All color changes maintain the same gradient structure and opacity values - only the hex color values were modified to create a cohesive warm orange aesthetic for the device frame mockup.

https://claude.ai/code/session_01Xie2VyWCNmJR2oCVPyYmBS