### PR TITLE
Atualizar formato da frase de população no card de estados

### DIFF
--- a/mapa/v1/app.js
+++ b/mapa/v1/app.js
@@ -326,7 +326,7 @@ const updatePanels = (id) => {
     els.total.textContent = formatter.format(totals.casamentos);
     els.men.textContent = formatter.format(totals.homem);
     els.women.textContent = formatter.format(totals.mulher);
-    els.note.textContent = `Aprox. ${approxPop(totals.pop)} era a população do país segundo o IBGE em 2024.`;
+    els.note.textContent = `Pop. de hab. estimada: ${approxPop(totals.pop)}, segundo IBGE/2024.`;
     return;
   }
 
@@ -345,7 +345,7 @@ const updatePanels = (id) => {
   els.total.textContent = formatter.format(state.casamentos);
   els.men.textContent = formatter.format(state.homem);
   els.women.textContent = formatter.format(state.mulher);
-  els.note.textContent = `Aprox. ${approxPop(state.pop)} era a população segundo o IBGE em 2024.`;
+  els.note.textContent = `Pop. de hab. estimada: ${approxPop(state.pop)}, segundo IBGE/2024.`;
 };
 
 const renderScroll = () => {


### PR DESCRIPTION
Modifica o formato da frase de população para o novo padrão:\n\n**Antes:** \"Aprox. X era a população segundo o IBGE em 2024.\"\n**Depois:** \"Pop. de hab. estimada: X, segundo IBGE/2024.\"

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ab2UvDix6KewksKzgf1Zu7)_